### PR TITLE
chore: move babel preset react app to dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.11.1",
+        "babel-preset-react-app": "^10.0.1",
         "eslint": "^8.57.1",
         "eslint-plugin-react": "^7.37.0",
         "globals": "^15.9.0"

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",
+    "babel-preset-react-app": "^10.0.1",
     "eslint": "^8.57.1",
     "eslint-plugin-react": "^7.37.0",
     "globals": "^15.9.0"


### PR DESCRIPTION
## Description

- Moved @babel-preset-react-app to dev dependency to remove build warning.