### PR TITLE
fix: change mobile no input type to number

### DIFF
--- a/src/pages/Register.js
+++ b/src/pages/Register.js
@@ -182,7 +182,7 @@ export default function Register() {
           <Form.Group className="mb-3" controlId="MobileNo">
             <Form.Label>Mobile No</Form.Label>
             <Form.Control
-              type="text"
+              type="number"
               placeholder="Enter a valid mobile number"
               value={mobileNo}
               onChange={(e) => setMobileNo(e.target.value)}


### PR DESCRIPTION
## Description

- Change mobile no input field type to "number" to prevent letter inputs.